### PR TITLE
Update bookmarks.model.ts: text defaults to null for mysql

### DIFF
--- a/src/models/bookmarks.model.ts
+++ b/src/models/bookmarks.model.ts
@@ -17,7 +17,7 @@ export class Bookmarks extends BaseEntity implements IBookmarks {
 
   @Column({
     type: 'text',
-    default: '',
+    default: null,
   })
   bookmarks: string;
 


### PR DESCRIPTION
Must be null for mysql to create tables without error.